### PR TITLE
Specified marc gem version for stability

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,5 @@ ASpaceGems.setup if defined? ASpaceGems
 source 'https://rubygems.org'
 
 gem 'aws-sdk-s3', '~> 1'
-gem 'marc'
+gem 'marc', '~> 1.1.1'
 gem 'mail'


### PR DESCRIPTION
The gem got updated to 1.2.0 on 2 August and our 3 August reboot of the Test environment failed. Correlation is not causality, but this seems to be the only correlation.